### PR TITLE
Set fanSpeed and swing regardless to enable all AC modes

### DIFF
--- a/PyTado/interface.py
+++ b/PyTado/interface.py
@@ -355,12 +355,15 @@ class Tado:
             "termination": {"typeSkillBasedApp": overlayMode},
         }
 
+        # fanSpeed and swing are required for some devices and must be sent otherwise
+        # you can't set some modes such as DRY
+        if fanSpeed is not None:
+            post_data["setting"]["fanSpeed"] = fanSpeed
+        if swing is not None:
+            post_data["setting"]["swing"] = swing
+
         if setTemp is not None:
             post_data["setting"]["temperature"] = {"celsius": setTemp}
-            if fanSpeed is not None:
-                post_data["setting"]["fanSpeed"] = fanSpeed
-            if swing is not None:
-                post_data["setting"]["swing"] = swing
 
         if mode is not None:
             post_data["setting"]["mode"] = mode
@@ -369,6 +372,9 @@ class Tado:
             post_data["termination"]["durationInSeconds"] = duration
 
         data = self._apiCall(cmd, "PUT", post_data)
+
+        # DEBUG purpose
+        _LOGGER.error(data)
         return data
         
     def getZoneOverlayDefault(self, zone):


### PR DESCRIPTION
## Overview

Closes [#47](https://github.com/wmalgadey/PyTado/issues/47)

Sets `fanSpeed` and `swing` to enable all AC modes. As described in the issue, if these values are not sent, then some registered devices will not work properly as the backend returns:
```
# {'errors': [{'code': 'setting.notSupported', 'title': 'fan speed not in supported fan speeds [AUTO, HIGH, LOW, MIDDLE]'}]}
```

This PR is for temporary testing and includes a DEBUG log.